### PR TITLE
Change apt key and change package name for Ubuntu.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,8 +32,8 @@ class ossec::params {
 
           case $::lsbdistcodename {
             /(precise|trusty|vivid|wily)/: {
-              $server_service = 'ossec-hids-server'
-              $server_package = 'ossec-hids-server'
+              $server_service = 'ossec'
+              $server_package = 'ossec-hids'
             }
             /^(jessie|wheezy|stretch|sid)$/: {
               $server_service = 'ossec'
@@ -71,7 +71,7 @@ class ossec::params {
       $config_file = regsubst(sprintf('c:/Program Files (x86)/ossec-agent/ossec.conf'), '\\', '/')
       $config_owner = 'Administrator'
       $config_group = 'Administrators'
- 
+
       $keys_file = regsubst(sprintf('c:/Program Files (x86)/ossec-agent/client.keys'), '\\', '/')
       $keys_mode = '0440'
       $keys_owner = 'Administrator'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,7 +5,7 @@ class ossec::repo (
     'Debian' : {
       case $::lsbdistcodename {
         /(precise|trusty|vivid|wily)/: {
-        
+
           apt::source { 'wazuh':
             ensure      => present,
             comment     => 'This is the WAZUH Ubuntu repository for Ossec',
@@ -14,7 +14,7 @@ class ossec::repo (
             repos       => 'main',
             include_src => false,
             include_deb => true,
-            key         => '9A1B1C65',
+            key         => '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',
             key_source  => 'http://ossec.wazuh.com/repos/apt/conf/ossec-key.gpg.key',
           }
           ~>
@@ -33,7 +33,7 @@ class ossec::repo (
             repos       => 'main',
             include_src => false,
             include_deb => true,
-            key         => '9A1B1C65',
+            key         => '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',
             key_source  => 'http://ossec.wazuh.com/repos/apt/conf/ossec-key.gpg.key',
           }
           ~>


### PR DESCRIPTION
The package name is changed for Ubuntu and the apt module from Puppet needs the full fingerprint.