### PR TITLE
Adding support for server-hostname in agent config

### DIFF
--- a/.fixtures.yaml
+++ b/.fixtures.yaml
@@ -1,3 +1,7 @@
 fixtures:
+  forge_modules:
+    stdlib: puppetlabs/stdlib
+    concat: puppetlabs/concat
+    epel: stahnma/epel
   symlinks:
     ossec: "#{source_dir}"

--- a/.fixtures.yaml
+++ b/.fixtures.yaml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    ossec: "#{source_dir}"

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,24 @@
+source 'https://rubygems.org'
+
+group :test do
+  gem 'rake'
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 4.2.0'
+  gem 'rspec', '< 3.2.0'
+  gem 'rspec-puppet', git: 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'rspec-puppet-facts'
+  gem 'autorun'
+
+  gem 'puppetlabs_spec_helper'
+end
+
+group :development do
+  gem 'puppet-blacksmith'
+  gem 'guard-rake'
+  gem 'yard'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'beaker-puppet_install_helper'
+end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -2,7 +2,8 @@
 class ossec::client(
   $ossec_active_response   = true,
   $ossec_rootcheck         = true,
-  $ossec_server_ip,
+  $ossec_server_ip         = undef,
+  $ossec_server_hostname   = undef,
   $ossec_emailnotification = 'yes',
   $ossec_ignorepaths       = [],
   $ossec_local_files       = {},
@@ -19,6 +20,9 @@ class ossec::client(
   #validate_integer($ossec_check_frequency, undef, 1800)
   validate_array($ossec_ignorepaths)
 
+  if ( ( $ossec_server_ip == undef ) and ( $ossec_server_hostname == undef ) ) {
+    fail('Either $ossec_server_ip or $ossec_server_hostname must be defined.')
+  }
 
   case $::kernel {
     'Linux' : {
@@ -36,7 +40,7 @@ class ossec::client(
       }
     }
     'windows' : {
-          
+
           file {
           'C:/ossec-win32-agent-2.8.3.exe':
           owner              => 'Administrators',

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -21,7 +21,7 @@ class ossec::client(
   validate_array($ossec_ignorepaths)
 
   if ( ( $ossec_server_ip == undef ) and ( $ossec_server_hostname == undef ) ) {
-    fail('Either $ossec_server_ip or $ossec_server_hostname must be defined.')
+    fail('must pass either $ossec_server_ip or $ossec_server_hostname to Class[\'ossec::client\'].')
   }
 
   case $::kernel {

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-describe 'ossec' do
+describe 'ossec::client' do
 
   context 'with defaults for all parameters' do
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('ossec') }
+    it { is_expected.to contain_class('ossec::client') }
   end
 end

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -19,6 +19,7 @@ describe 'ossec::client' do
         end
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('ossec::client') }
+        it { is_expected.not_to contain_Concat__Fragment('ossec.conf_10').with_content(/<server-hostname>local.test<\/server-hostname>/) }
         it { is_expected.to contain_Concat__Fragment('ossec.conf_10').with_content(/<server-ip>127.0.0.1<\/server-ip>/) }
       end
 
@@ -30,6 +31,7 @@ describe 'ossec::client' do
         end
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('ossec::client') }
+        it { is_expected.not_to contain_Concat__Fragment('ossec.conf_10').with_content(/<server-ip>127.0.0.1<\/server-ip>/) }
         it { is_expected.to contain_Concat__Fragment('ossec.conf_10').with_content(/<server-hostname>local.test<\/server-hostname>/) }
       end
     end

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,8 +1,37 @@
 require 'spec_helper'
 describe 'ossec::client' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let (:facts) do
+        facts.merge({ :concat_basedir => '/dummy' })
+      end
+      context 'with defaults for all parameters' do
+        it do
+          expect { is_expected.to compile.with_all_deps }.to raise_error(/must pass either/)
+        end
+      end
 
-  context 'with defaults for all parameters' do
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('ossec::client') }
+      context 'with ossec_server_ip' do
+        let (:params) do
+          {
+            :ossec_server_ip => '127.0.0.1',
+          }
+        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('ossec::client') }
+        it { is_expected.to contain_Concat__Fragment('ossec.conf_10').with_content(/<server-ip>127.0.0.1<\/server-ip>/) }
+      end
+
+      context 'with ossec_server_hostname' do
+        let (:params) do
+          {
+            :ossec_server_hostname => 'local.test',
+          }
+        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('ossec::client') }
+        it { is_expected.to contain_Concat__Fragment('ossec.conf_10').with_content(/<server-hostname>local.test<\/server-hostname>/) }
+      end
+    end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 describe 'ossec' do
-
-  context 'with defaults for all parameters' do
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('ossec') }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let (:facts) { facts }
+      context 'with defaults for all parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('ossec') }
+      end
+    end
   end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,8 +1,25 @@
 require 'spec_helper'
 describe 'ossec::server' do
-
-  context 'with defaults for all parameters' do
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('ossec::server') }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let (:facts) do
+        facts.merge({ :concat_basedir => '/dummy' })
+      end
+      context 'with defaults for all parameters' do
+        it do
+          expect { is_expected.to compile.with_all_deps }.to raise_error(/Must pass mailserver_ip/)
+        end
+      end
+      context 'with valid paramaters' do
+        let (:params) do
+          {
+            :mailserver_ip => '127.0.0.1',
+            :ossec_emailto => 'root@localhost.localdomain',
+          }
+        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('ossec::server') }
+      end
+    end
   end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-describe 'ossec' do
+describe 'ossec::server' do
 
   context 'with defaults for all parameters' do
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('ossec') }
+    it { is_expected.to contain_class('ossec::server') }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,14 +4,18 @@ $LOAD_PATH.unshift File.join(dir, 'lib')
 require 'mocha'
 require 'puppet'
 require 'rspec'
-require 'spec/autorun'
+require 'rspec-puppet-facts'
+require 'puppetlabs_spec_helper/module_spec_helper'
 
-Spec::Runner.configure do |config|
+#require 'spec/autorun'
+
+#Spec::Runner.configure do |config|
+RSpec.configure do |config|
     config.mock_with :mocha
 end
 
 # We need this because the RAL uses 'should' as a method.  This
 # allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
-end
+#class Object
+#    alias :must :should
+#end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'rspec'
 require 'rspec-puppet-facts'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
+include RspecPuppetFacts
+
 #require 'spec/autorun'
 
 #Spec::Runner.configure do |config|

--- a/templates/10_ossec_agent.conf.erb
+++ b/templates/10_ossec_agent.conf.erb
@@ -1,6 +1,11 @@
 <ossec_config>
   <client>
+<% if @ossec_server_ip then %>
     <server-ip><%= @ossec_server_ip %></server-ip>
+<% end %>
+<% if @ossec_server_hostname then %>
+    <server-hostname><%= @ossec_server_hostname %></server-hostname>
+<% end %>
   </client>
 
   <syscheck>


### PR DESCRIPTION
Ran into this when attempting an ossec server instance in AWS;  since EC2/R53/EIP interactions require the use of DNS, agent must be configured via server-hostname in lieu of server-ip.

apologies on the spec mess that was included.  went down a bit of a rabbit hole looking for a working spec/autorun configuration, but did not find anything conclusive beyond a few posts mentioning that it was no longer used?    added enough coverage to sanely do the hostname update, but should not be considered conclusive. 