### PR TITLE
Use internal path variable for erb in ossec config instead of global

### DIFF
--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -82,7 +82,7 @@
 <% end %>
 
     <!-- Files/directories to ignore (parameterized) -->
-<% @ossec_ignorepaths.each do |path| -%>    <ignore><%= @path %></ignore>
+<% @ossec_ignorepaths.each do |path| -%>    <ignore><%= path %></ignore>
 <% end %>
   </syscheck>
 

--- a/templates/10_ossec_agent.conf.erb
+++ b/templates/10_ossec_agent.conf.erb
@@ -18,7 +18,7 @@
 <% end %>
 
     <!-- Files/directories to ignore (parameterized) -->
-<% @ossec_ignorepaths.each do |path| -%>    <ignore><%= @path %></ignore>
+<% @ossec_ignorepaths.each do |path| -%>    <ignore><%= path %></ignore>
 <% end %>
   </syscheck>
 


### PR DESCRIPTION
The @path uses the puppet level path variable (which, gives all the path statements: /bin:/sbin:etc). We actually want the path from the each.