### PR TITLE
Manage client keys option

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -12,6 +12,7 @@ class ossec::client(
   $selinux                 = false,
   $manage_repo             = true,
   $manage_epel_repo        = true,
+  $manage_client_keys      = true,
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
@@ -92,7 +93,7 @@ class ossec::client(
     notify  => Service[$ossec::params::agent_service]
   }
 
-  if ( $ossec::params::manage_client_keys == true ) {
+  if ( $manage_client_keys == true ) {
     concat { $ossec::params::keys_file:
       owner   => $ossec::params::keys_owner,
       group   => $ossec::params::keys_group,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -92,24 +92,26 @@ class ossec::client(
     notify  => Service[$ossec::params::agent_service]
   }
 
-  concat { $ossec::params::keys_file:
-    owner   => $ossec::params::keys_owner,
-    group   => $ossec::params::keys_group,
-    mode    => $ossec::params::keys_mode,
-    notify  => Service[$ossec::params::agent_service],
-    require => Package[$ossec::params::agent_package]
-  }
+  if ( $ossec::params::manage_client_keys == true ) {
+    concat { $ossec::params::keys_file:
+      owner   => $ossec::params::keys_owner,
+      group   => $ossec::params::keys_group,
+      mode    => $ossec::params::keys_mode,
+      notify  => Service[$ossec::params::agent_service],
+      require => Package[$ossec::params::agent_package]
+    }
 
-  ossec::agentkey{ "ossec_agent_${::fqdn}_client":
-    agent_id         => fqdn_rand(3000),
-    agent_name       => $::hostname,
-    agent_ip_address => $::ipaddress,
-  }
+    ossec::agentkey{ "ossec_agent_${::fqdn}_client":
+      agent_id         => fqdn_rand(3000),
+      agent_name       => $::hostname,
+      agent_ip_address => $::ipaddress,
+    }
 
-  @@ossec::agentkey{ "ossec_agent_${::fqdn}_server":
-    agent_id         => fqdn_rand(3000),
-    agent_name       => $::hostname,
-    agent_ip_address => $::ipaddress
+    @@ossec::agentkey{ "ossec_agent_${::fqdn}_server":
+      agent_id         => fqdn_rand(3000),
+      agent_name       => $::hostname,
+      agent_ip_address => $::ipaddress
+    }
   }
 
   if ($::kernel == 'Linux') {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,4 @@
-class ossec::params (
-  $manage_client_keys = true,
-) {
+class ossec::params {
   case $::kernel {
     'Linux': {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,6 @@
-class ossec::params {
+class ossec::params (
+  $manage_client_keys = true,
+) {
   case $::kernel {
     'Linux': {
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -77,18 +77,20 @@ class ossec::server (
     notify  => Service[$ossec::params::server_service]
   }
 
-  concat { $ossec::params::keys_file:
-    owner   => $ossec::params::keys_owner,
-    group   => $ossec::params::keys_group,
-    mode    => $ossec::params::keys_mode,
-    notify  => Service[$ossec::params::server_service],
-    require => Package[$ossec::params::server_package],
-  }
-  concat::fragment { 'var_ossec_etc_client.keys_end' :
-    target  => $ossec::params::keys_file,
-    order   => 99,
-    content => "\n",
-    notify  => Service[$ossec::params::server_service]
+  if ( $ossec::params::manage_client_keys == true ) {
+    concat { $ossec::params::keys_file:
+      owner   => $ossec::params::keys_owner,
+      group   => $ossec::params::keys_group,
+      mode    => $ossec::params::keys_mode,
+      notify  => Service[$ossec::params::server_service],
+      require => Package[$ossec::params::server_package],
+    }
+    concat::fragment { 'var_ossec_etc_client.keys_end' :
+      target  => $ossec::params::keys_file,
+      order   => 99,
+      content => "\n",
+      notify  => Service[$ossec::params::server_service]
+    }
   }
 
   file { '/var/ossec/etc/shared/agent.conf':

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,6 +17,7 @@ class ossec::server (
   $use_mysql                           = false,
   $manage_repos                        = true,
   $manage_epel_repo                    = true,
+  $manage_client_keys                  = true,
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
@@ -77,7 +78,7 @@ class ossec::server (
     notify  => Service[$ossec::params::server_service]
   }
 
-  if ( $ossec::params::manage_client_keys == true ) {
+  if ( $manage_client_keys == true ) {
     concat { $ossec::params::keys_file:
       owner   => $ossec::params::keys_owner,
       group   => $ossec::params::keys_group,


### PR DESCRIPTION
Provides an option to tell the puppet module to not manage the client.keys file at all.

I don't want to the module to manage/overwrite it at all.

Not sure if you want to pull this, but I believe it could be useful. For someone with an existing OSSEC installation, this can prevent them from having their client.keys overwritten or deleted by the module.
