### PR TITLE
Manage client keys

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -126,6 +126,13 @@ class ossec::client(
       mode    => '0755',
     }
 
+    # If client.keys doesn't exist on agent, register it with the OSSEC server
+    exec { "agent-auth":
+      command   	=> "/var/ossec/bin/agent-auth -m $ossec_server_ip -A $::fqdn -D /var/ossec/",
+      creates   	=> "/var/ossec/etc/client.keys",
+      require => Package[$ossec::params::agent_package],
+    }
+
     # SELinux
     # Requires selinux module specified in metadata.json
     if ($::osfamily == 'RedHat' and $selinux == true) {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -127,10 +127,18 @@ class ossec::client(
     }
 
     # If client.keys doesn't exist on agent, register it with the OSSEC server
-    exec { "agent-auth":
-      command   	=> "/var/ossec/bin/agent-auth -m $ossec_server_ip -A $::fqdn -D /var/ossec/",
-      creates   	=> "/var/ossec/etc/client.keys",
-      require => Package[$ossec::params::agent_package],
+    if ( ( $ossec_server_ip != undef ) ) {
+      exec { "agent-auth":
+        command   	=> "/var/ossec/bin/agent-auth -m $ossec_server_ip -A $::fqdn -D /var/ossec/",
+        creates   	=> "/var/ossec/etc/client.keys",
+        require => Package[$ossec::params::agent_package],
+      }
+    } elsif ( ( $ossec_server_hostname != undef ) ) {
+      exec { "agent-auth":
+        command   	=> "/var/ossec/bin/agent-auth -m $ossec_server_hostname -A $::fqdn -D /var/ossec/",
+        creates   	=> "/var/ossec/etc/client.keys",
+        require => Package[$ossec::params::agent_package],
+      }
     }
 
     # SELinux


### PR DESCRIPTION
This should have been part of my previous pull request, but got missed. If the client.keys file on the agent does not exist yet, that means we want to have it register itself with the server.
