### PR TITLE
Change log directory to only be readable by user and group

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -123,7 +123,7 @@ class ossec::client(
       require => Package[$ossec::params::agent_package],
       owner   => 'ossec',
       group   => 'ossec',
-      mode    => '0755',
+      mode    => '0750',
     }
 
     # If client.keys doesn't exist on agent, register it with the OSSEC server


### PR DESCRIPTION
The package on Ubuntu has permissions on the log directory of `0750`, so changing
the mode to `0755` is causing the permissions to be more lax.