### PR TITLE
Add the ability to configure a MySQL database with OSSEC server

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,11 @@ class ossec::params {
       $keys_owner = 'root'
       $keys_group = 'ossec'
 
+      $processlist_file = '/var/ossec/bin/.process_list'
+      $processlist_mode = '0440'
+      $processlist_owner = 'root'
+      $processlist_group = 'ossec'
+
       case $::osfamily {
         'Debian': {
 

--- a/templates/10_process_list.erb
+++ b/templates/10_process_list.erb
@@ -1,0 +1,2 @@
+# This file managed by Puppet.
+# Any changes will be overwritten

--- a/templates/20_process_list.erb
+++ b/templates/20_process_list.erb
@@ -1,0 +1,1 @@
+DB_DAEMON=ossec-dbd

--- a/templates/80_ossec.conf.erb
+++ b/templates/80_ossec.conf.erb
@@ -1,0 +1,7 @@
+  <database_output>
+    <hostname><%= @mysql_hostname %></hostname>
+    <username><%= @mysql_username %></username>
+    <password><%= @mysql_password %></password>
+    <database><%= @mysql_name %></database>
+    <type>mysql</type>
+  </database_output>


### PR DESCRIPTION
This also required adding automation for the `.process_list` file which keeps track of any additional processes that need to be started/shutdown with ossec-hids.