### PR TITLE
Extra rules config

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,6 +11,7 @@ class ossec::server (
   $ossec_ignorepaths                   = [],
   $ossec_scanpaths                     = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'yes', 'realtime' => 'yes'} ],
   $ossec_white_list                    = [],
+  $ossec_extra_rules_config            = [],
   $ossec_local_files                   = {},
   $ossec_emailnotification             = 'yes',
   $ossec_check_frequency               = 79200,

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -70,6 +70,9 @@
     <include>asterisk_rules.xml</include>
     <include>ossec_rules.xml</include>
     <include>attack_rules.xml</include>
+    <% @ossec_extra_rules_config.each do |rule_config| -%>
+    <%= rule_config %>
+    <% end -%>
     <include>local_rules.xml</include>
   </rules>
 

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -72,7 +72,7 @@
     <include>attack_rules.xml</include>
     <% @ossec_extra_rules_config.each do |rule_config| -%>
     <%= rule_config %>
-    <% end -%>
+<% end -%>
     <include>local_rules.xml</include>
   </rules>
 


### PR DESCRIPTION
Enabling the Wazuh ruleset makes changes to the ossec.conf on the OSSEC server. Unfortunately the next time puppet runs on the OSSEC server, it wants to undo those changes.

This is a patch to help workaround that by allowing you to specify extra configurations for the <rules> section in the ossec.conf.

To use it, after enabling the Wazuh ruleset (either manually or via the automated script), take a look at the changes made to the ossec.conf file. You will need to put these same changes into the "$ossec_extra_rules_config" array parameter when calling the ossec::server class.

Consequently, if you add or remove any of the Wazuh rules later on, you'll need to ensure to add/remove the appropriate bits in the "$ossec_extra_rules_config" array parameter as well.
