### PR TITLE
adding auto_ignore

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,6 +17,7 @@ class ossec::server (
   $ossec_email_maxperhour              = '12',
   $ossec_email_idsname                 = undef,
   $ossec_check_frequency               = 79200,
+  $ossec_auto_ignore                   = 'yes',
   $use_mysql                           = false,
   $mariadb                             = false,
   $mysql_hostname                      = undef,

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -86,6 +86,7 @@
     <!-- Frequency that syscheck is executed -->
     <frequency><%= @ossec_check_frequency %></frequency>
     <alert_new_files>yes</alert_new_files>
+    <auto_ignore><%= @ossec_auto_ignore %></auto_ignore>
 
    <!-- Directories to check  (perform all possible verifications) -->
    <% @ossec_scanpaths.each do |scanpath| -%>    <directories check_all="yes" report_changes="<%= scanpath["report_changes"] %>" realtime="<%= scanpath['realtime'] %>"><%= scanpath['path']  %></directories>


### PR DESCRIPTION
puppet module does not support disabling auto_ignore in syscheck.
This change will permit admin to disable auto_ignore for files which change more than three times.