### PR TITLE
repeated_offenders needs to be set for each agent.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -191,5 +191,6 @@ Jose Luis Ruiz <jose@wazuh.com>:
 
 Jose Luis Ruiz <jose@wazuh.com>:
 
-  * Ppermit admin to disable auto_ignore for files which change more than three times. (pull request #24 thanks @cmblong)
   * Add MariaDB support ( (pull reques #3 thanks @ialokin)
+  * Permit admin to disable auto_ignore for files which change more than three times. (pull request #24 thanks @cmblong)
+  * Change fqdn_rand(3000) to a variable to allow us to increase the number of available clients. (pull request #25 thanks @cmblong)

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,12 +15,8 @@ class ossec::client(
   $manage_repo             = true,
   $manage_epel_repo        = true,
   $manage_client_keys      = true,
-<<<<<<< HEAD
-
   $max_clients             = 3000,
-=======
   $ar_repeated_offenders   = '',
->>>>>>> 6622aa7096acb798db86c8d0518113bb412a1551
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,8 +15,12 @@ class ossec::client(
   $manage_repo             = true,
   $manage_epel_repo        = true,
   $manage_client_keys      = true,
+<<<<<<< HEAD
 
   $max_clients             = 3000,
+=======
+  $ar_repeated_offenders   = '',
+>>>>>>> 6622aa7096acb798db86c8d0518113bb412a1551
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
@@ -90,6 +94,15 @@ class ossec::client(
     notify  => Service[$ossec::params::agent_service]
   }
 
+  if ( $ar_repeated_offenders != '' ) {
+    concat::fragment { 'repeated_offenders' :
+      target  => $ossec::params::config_file,
+      content => template('ossec/ar_repeated_offenders.erb'),
+      order   => 55,
+      notify  => Service[$ossec::params::agent_service]
+    }
+  }
+  
   concat::fragment { 'ossec.conf_99' :
     target  => $ossec::params::config_file,
     content => template('ossec/99_ossec_agent.conf.erb'),

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,6 +15,7 @@ class ossec::client(
   $manage_repo             = true,
   $manage_epel_repo        = true,
   $manage_client_keys      = true,
+  $max_clients             = 3000,
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
@@ -105,13 +106,13 @@ class ossec::client(
     }
 
     ossec::agentkey{ "ossec_agent_${agent_name}_client":
-      agent_id         => fqdn_rand(3000),
+      agent_id         => fqdn_rand($max_clients),
       agent_name       => $agent_name,
       agent_ip_address => $agent_ip_address,
     }
 
     @@ossec::agentkey{ "ossec_agent_${agent_name}_server":
-      agent_id         => fqdn_rand(3000),
+      agent_id         => fqdn_rand($max_clients),
       agent_name       => $agent_name,
       agent_ip_address => $agent_ip_address
     }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,6 +15,7 @@ class ossec::client(
   $manage_repo             = true,
   $manage_epel_repo        = true,
   $manage_client_keys      = true,
+
   $max_clients             = 3000,
 ) inherits ossec::params {
   validate_bool(

--- a/templates/ar_repeated_offenders.erb
+++ b/templates/ar_repeated_offenders.erb
@@ -1,0 +1,3 @@
+  <active-response>
+	<repeated_offenders><%= @ar_repeated_offenders %></repeated_offenders>
+  </active-response>


### PR DESCRIPTION
You can now set a minimal activeresponse entry containing just repeated_offenders by defining $ar_repeated_offenders in the ossec::client class:

class { "ossec::client":
  ar_repeated_offenders => '100,200,300,400,500',
}