### PR TITLE
add variable to enable prefilter command

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,6 +9,7 @@ class ossec::client(
   $ossec_ignorepaths       = [],
   $ossec_local_files       = {},
   $ossec_check_frequency   = 79200,
+  $ossec_prefilter         = false,
   $selinux                 = false,
   $agent_name              = $::hostname,
   $agent_ip_address        = $::ipaddress,

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -96,6 +96,9 @@
 <% @ossec_ignorepaths.each do |path| -%>
     <ignore><%= path %></ignore>
 <% end -%>
+<% if @ossec_prefilter == true then %>
+    <prefilter_cmd>/usr/sbin/prelink -y</prefilter_cmd>
+<% end %>
   </syscheck>
 
 <% if @ossec_rootcheck == false then -%>


### PR DESCRIPTION
when prelinking is enabled in the os, identical binaries are producing different hashes.  rhel6 for example enables prelinking by default.  ossec provides the functionality to prefilter file hashing with /usr/bin/prelink -y which will cause identical binaries to produce identical hashes.  this change will enable a variable, disabled by default, which will add the prefilter directive to the ossec.conf.erb.