### PR TITLE
set service provider to redhat on redhat systems

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -10,6 +10,7 @@ class ossec::client(
   $ossec_local_files       = {},
   $ossec_check_frequency   = 79200,
   $ossec_prefilter         = false,
+  $ossec_service_provider  = $::ossec::params::ossec_service_provider,
   $selinux                 = false,
   $agent_name              = $::hostname,
   $agent_ip_address        = $::ipaddress,
@@ -73,6 +74,7 @@ class ossec::client(
     enable    => true,
     hasstatus => $ossec::params::service_has_status,
     pattern   => $ossec::params::agent_service,
+    provider  => $ossec_service_provider,
     require   => Package[$ossec::params::agent_package],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,8 @@ class ossec::params {
 
           $service_has_status  = false
 
+          $ossec_service_provider = undef
+
           $default_local_files = {
             '/var/log/syslog'             => 'syslog',
             '/var/log/auth.log'           => 'syslog',
@@ -59,6 +61,8 @@ class ossec::params {
           $server_package = 'ossec-hids'
 
           $service_has_status  = true
+
+          $ossec_service_provider = 'redhat'
 
           $default_local_files = {
             '/var/log/messages'         => 'syslog',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,6 +19,7 @@ class ossec::server (
   $ossec_check_frequency               = 79200,
   $ossec_auto_ignore                   = 'yes',
   $ossec_prefilter                     = false,
+  $ossec_service_provider              = $::ossec::params::ossec_service_provider,
   $use_mysql                           = false,
   $mariadb                             = false,
   $mysql_hostname                      = undef,
@@ -69,6 +70,7 @@ class ossec::server (
     enable    => true,
     hasstatus => $ossec::params::service_has_status,
     pattern   => $ossec::params::server_service,
+    provider  => $ossec_service_provider,
     require   => Package[$ossec::params::server_package],
   }
 


### PR DESCRIPTION
On RHEL7 systems the default provider does not correctly handle legacy init scripts, causing puppet to always change the service from stopped->running. Setting this to the 'redhat' provider allows puppet to correctly check the status of the service.