### PR TITLE
Option to enable syslog output

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,10 +29,13 @@ class ossec::server (
   $manage_repos                        = true,
   $manage_epel_repo                    = true,
   $manage_client_keys                  = true,
+  $syslog_output                       = false,
+  $syslog_output_server                = undef,
+  $syslog_output_format                = undef,
 ) inherits ossec::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
-    $use_mysql, $manage_repos, $manage_epel_repo
+    $use_mysql, $manage_repos, $manage_epel_repo, $syslog_output
   )
   # This allows arrays of integers, sadly
   # (commented due to stdlib version requirement)

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -17,6 +17,13 @@
     <% end %>
   </global>
 
+<% if @syslog_output == true then -%>
+  <syslog_output>
+    <server><%= @syslog_output_server %></server>
+    <format><%= @syslog_output_format %></format>
+  </syslog_output>
+<% end -%>
+
   <!-- Included rules (static) -->
   <rules>
     <include>rules_config.xml</include>

--- a/templates/10_process_list.erb
+++ b/templates/10_process_list.erb
@@ -1,2 +1,5 @@
 # This file managed by Puppet.
 # Any changes will be overwritten
+<% if @syslog_output == true then -%>
+CSYSLOG_DAEMON=ossec-csyslogd
+<% end -%>

--- a/templates/20_process_list.erb
+++ b/templates/20_process_list.erb
@@ -1,1 +1,4 @@
 DB_DAEMON=ossec-dbd
+<% if @syslog_output == true then -%>
+CSYSLOG_DAEMON=ossec-csyslogd
+<% end -%>

--- a/templates/20_process_list.erb
+++ b/templates/20_process_list.erb
@@ -1,4 +1,1 @@
 DB_DAEMON=ossec-dbd
-<% if @syslog_output == true then -%>
-CSYSLOG_DAEMON=ossec-csyslogd
-<% end -%>


### PR DESCRIPTION
This pull request adds the option to enable syslog output, including specifying the syslog server and the format of the output. This can be useful for forwarding alerts into an ELK-like stack.