### PR TITLE
override package & service name for client installation

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -17,6 +17,8 @@ class ossec::client(
   $manage_repo             = true,
   $manage_epel_repo        = true,
   $agent_package_name      = $::ossec::params::agent_package,
+  $agent_service_name      = $::ossec::params::agent_service,
+
   $manage_client_keys      = true,
   $max_clients             = 3000,
   $ar_repeated_offenders   = '',
@@ -71,11 +73,11 @@ class ossec::client(
     default: { fail('OS not supported') }
   }
 
-  service { $ossec::params::agent_service:
+  service { $agent_service_name:
     ensure    => running,
     enable    => true,
     hasstatus => $ossec::params::service_has_status,
-    pattern   => $ossec::params::agent_service,
+    pattern   => $agent_service_name,
     provider  => $ossec_service_provider,
     require   => Package[$agent_package_name],
   }
@@ -85,14 +87,14 @@ class ossec::client(
     group   => $ossec::params::config_group,
     mode    => $ossec::params::config_mode,
     require => Package[$agent_package_name],
-    notify  => Service[$ossec::params::agent_service],
+    notify  => Service[$agent_service_name],
   }
 
   concat::fragment { 'ossec.conf_10' :
     target  => $ossec::params::config_file,
     content => template('ossec/10_ossec_agent.conf.erb'),
     order   => 10,
-    notify  => Service[$ossec::params::agent_service]
+    notify  => Service[$agent_service_name]
   }
 
   if ( $ar_repeated_offenders != '' and $ossec_active_response == true ) {
@@ -100,15 +102,15 @@ class ossec::client(
       target  => $ossec::params::config_file,
       content => template('ossec/ar_repeated_offenders.erb'),
       order   => 55,
-      notify  => Service[$ossec::params::agent_service]
+      notify  => Service[$agent_service_name]
     }
   }
-  
+
   concat::fragment { 'ossec.conf_99' :
     target  => $ossec::params::config_file,
     content => template('ossec/99_ossec_agent.conf.erb'),
     order   => 99,
-    notify  => Service[$ossec::params::agent_service]
+    notify  => Service[$agent_service_name]
   }
 
   if ( $manage_client_keys == true ) {
@@ -116,7 +118,7 @@ class ossec::client(
       owner   => $ossec::params::keys_owner,
       group   => $ossec::params::keys_group,
       mode    => $ossec::params::keys_mode,
-      notify  => Service[$ossec::params::agent_service],
+      notify  => Service[$agent_service_name],
       require => Package[$agent_package_name]
     }
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -117,7 +117,7 @@ class ossec::client(
       group   => $ossec::params::keys_group,
       mode    => $ossec::params::keys_mode,
       notify  => Service[$ossec::params::agent_service],
-      require => Package[$ossec::params::agent_package]
+      require => Package[$agent_package_name]
     }
 
     ossec::agentkey{ "ossec_agent_${agent_name}_client":
@@ -137,7 +137,7 @@ class ossec::client(
     exec { 'agent-auth':
       command => "/var/ossec/bin/agent-auth -m ${ossec_server_address} -A ${::fqdn} -D /var/ossec/",
       creates => '/var/ossec/etc/client.keys',
-      require => Package[$ossec::params::agent_package],
+      require => Package[$agent_package_name],
     }
   }
 
@@ -146,7 +146,7 @@ class ossec::client(
     # https://github.com/djjudas21/puppet-ossec/issues/20
     file { '/var/ossec/logs':
       ensure  => directory,
-      require => Package[$ossec::params::agent_package],
+      require => Package[$agent_package_name],
       owner   => 'ossec',
       group   => 'ossec',
       mode    => '0750',

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -18,7 +18,6 @@ class ossec::client(
   $manage_epel_repo        = true,
   $agent_package_name      = $::ossec::params::agent_package,
   $agent_service_name      = $::ossec::params::agent_service,
-
   $manage_client_keys      = true,
   $max_clients             = 3000,
   $ar_repeated_offenders   = '',

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -31,6 +31,7 @@ class ossec::client(
   #validate_integer($ossec_check_frequency, undef, 1800)
   validate_array($ossec_ignorepaths)
   validate_string($agent_package_name)
+  validate_string($agent_service_name)
 
   if ( ( $ossec_server_ip == undef ) and ( $ossec_server_hostname == undef ) ) {
     fail('must pass either $ossec_server_ip or $ossec_server_hostname to Class[\'ossec::client\'].')


### PR DESCRIPTION
Allow the client package and service names to be overridden via parameters to the ossec::client class.