### PR TITLE
Fix apt deprecation warnings

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -40,8 +40,10 @@ class ossec::repo (
             location    => 'http://ossec.wazuh.com/repos/apt/ubuntu',
             release     => $::lsbdistcodename,
             repos       => 'main',
-            include_src => false,
-            include_deb => true,
+            include     => {
+              'src' => false,
+              'deb' => true,
+            },
           }
           ~>
           exec { 'update-apt-wazuh-repo':
@@ -57,8 +59,10 @@ class ossec::repo (
             location    => 'http://ossec.wazuh.com/repos/apt/debian',
             release     => $::lsbdistcodename,
             repos       => 'main',
-            include_src => false,
-            include_deb => true,
+            include     => {
+              'src' => false,
+              'deb' => true,
+            },
           }
           ~>
           exec { 'update-apt-wazuh-repo':


### PR DESCRIPTION
Running this module with puppetlabs-apt v2.3.0 I was getting
warnings such as:

Warning: Scope(Apt::Source[wazuh]): $include_src is deprecated and
will be removed in the next major release, please use
$include => { 'src' => false } instead