### PR TITLE
Avoid warnings when storeconfigs are not available

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -123,17 +123,11 @@ class ossec::client(
       notify  => Service[$agent_service_name],
       require => Package[$agent_package_name]
     }
-
-    ossec::agentkey{ "ossec_agent_${agent_name}_client":
-      agent_id         => fqdn_rand($max_clients),
+    # A separate module to avoid storeconfigs warnings when not managing keys
+    class { 'ossec::export_agent_key':
+      max_clients      => $max_clients,
       agent_name       => $agent_name,
       agent_ip_address => $agent_ip_address,
-    }
-
-    @@ossec::agentkey{ "ossec_agent_${agent_name}_server":
-      agent_id         => fqdn_rand($max_clients),
-      agent_name       => $agent_name,
-      agent_ip_address => $agent_ip_address
     }
   } elsif ($::kernel == 'Linux') {
     # Is this really Linux only?

--- a/manifests/collect_agent_keys.pp
+++ b/manifests/collect_agent_keys.pp
@@ -1,0 +1,3 @@
+class ossec::collect_agent_keys {
+  Ossec::Agentkey<<| |>>
+}

--- a/manifests/export_agent_key.pp
+++ b/manifests/export_agent_key.pp
@@ -1,0 +1,13 @@
+class ossec::export_agent_key($max_clients, $agent_name, $agent_ip_address) {
+  ossec::agentkey{ "ossec_agent_${agent_name}_client":
+    agent_id         => fqdn_rand($max_clients),
+    agent_name       => $agent_name,
+    agent_ip_address => $agent_ip_address,
+  }
+
+  @@ossec::agentkey{ "ossec_agent_${agent_name}_server":
+    agent_id         => fqdn_rand($max_clients),
+    agent_name       => $agent_name,
+    agent_ip_address => $agent_ip_address
+  }
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -183,7 +183,8 @@ class ossec::server (
     require => Package[$ossec::params::server_package]
   }
 
-
-  Ossec::Agentkey<<| |>>
-
+  if ( $manage_client_keys == true ) {
+    # A separate module to avoid storeconfigs warnings when not managing keys
+    include ossec::collect_agent_keys
+  }
 }


### PR DESCRIPTION
For masterless puppet deployments exported resources generate
warnings.

Puppet will complain unless the exports/collection are moved to
separate modules that aren't included.