### PR TITLE
Use default local_files setting

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -7,7 +7,7 @@ class ossec::client(
   $ossec_scanpaths         = [],
   $ossec_emailnotification = 'yes',
   $ossec_ignorepaths       = [],
-  $ossec_local_files       = {},
+  $ossec_local_files       = $::ossec::params::default_local_files,
   $ossec_check_frequency   = 79200,
   $ossec_prefilter         = false,
   $ossec_service_provider  = $::ossec::params::ossec_service_provider,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -12,7 +12,7 @@ class ossec::server (
   $ossec_scanpaths                     = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'yes', 'realtime' => 'yes'} ],
   $ossec_white_list                    = [],
   $ossec_extra_rules_config            = [],
-  $ossec_local_files                   = {},
+  $ossec_local_files                   = $::ossec::params::default_local_files,
   $ossec_emailnotification             = 'yes',
   $ossec_email_maxperhour              = '12',
   $ossec_email_idsname                 = undef,


### PR DESCRIPTION
The list of log files to monitor was configured in params.pp, but
was not used anywhere.

This meant that a default installation of this module would not
monitor any logs on either the client or server.