### PR TITLE
Fixed osfamily letter casing for RedHat in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,7 @@ class ossec::params {
           }
 
         }
-        'Linux', 'Redhat': {
+        'Linux', 'RedHat': {
 
           $agent_service  = 'ossec-hids-agent'
 


### PR DESCRIPTION
Changed param.pp "$::osfamily" switch statement string comparison to be an exact match for the puppet fact.