### PR TITLE
use puppet-selinux instead of jfryman-selinux

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -75,8 +75,8 @@
       "version_range": ">= 2.0.0"
     },
     {
-      "name": "jfryman/selinux",
-      "version_range": ">= 0.2.3"
+      "name": "puppet/selinux",
+      "version_range": ">= 0.8.0"
     },
     { 
       "name": "puppetlabs/mysql",


### PR DESCRIPTION
jfryman-selinux is no more in dev.
it said that we should change this to puppet-selinux.

I applied this on the metadata.json file.