### PR TITLE
Checks to see if keys file exists and is not of zero size

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -138,8 +138,9 @@ class ossec::client(
     # Is this really Linux only?
     $ossec_server_address = pick($ossec_server_ip, $ossec_server_hostname)
     exec { 'agent-auth':
+      path    => '/usr/bin:/usr/sbin:/bin',
       command => "/var/ossec/bin/agent-auth -m ${ossec_server_address} -A ${::fqdn} -D /var/ossec/",
-      creates => '/var/ossec/etc/client.keys',
+      unless  => 'test -s /var/ossec/etc/client.keys',
       require => Package[$agent_package_name],
     }
   }


### PR DESCRIPTION
The debian package installs a zero byte file at /var/ossec/etc/client.keys. When "manage_client_keys" is "false", this prevents the keys from being generated as the file /var/ossec/etc/client.keys already exists.