### PR TITLE
Adding ability to pass syslog output port

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -37,6 +37,7 @@ class ossec::server (
   $manage_client_keys                  = true,
   $syslog_output                       = false,
   $syslog_output_server                = undef,
+  $syslog_output_server_port           = 514,
   $syslog_output_format                = undef,
   $local_decoder_template              = 'ossec/local_decoder.xml.erb',
   $local_rules_template                = 'ossec/local_rules.xml.erb',

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -20,6 +20,7 @@
 <% if @syslog_output == true then -%>
   <syslog_output>
     <server><%= @syslog_output_server %></server>
+    <port><%= @syslog_output_server_port %></port>
     <format><%= @syslog_output_format %></format>
   </syslog_output>
 <% end -%>


### PR DESCRIPTION
Trying to add the ability to pass port number for the remote syslog output server. Based on the ossec documentation, the default value if not defined is always 514. 
This way if someone is using a non standard port, they can overwrite with the suitable value. 