### PR TITLE
Allow log_alert_level as parameter for server configuration

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,6 +11,7 @@ class ossec::server (
   $ossec_global_host_information_level = 8,
   $ossec_global_stat_level             = 8,
   $ossec_email_alert_level             = 7,
+  $ossec_log_alert_level               = 1,
   $ossec_ignorepaths                   = [],
   $ossec_ignorepaths_regex             = [],
   $ossec_scanpaths                     = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'yes', 'realtime' => 'yes'} ],

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -154,7 +154,7 @@
   </remote>
 
   <alerts>
-    <log_alert_level>1</log_alert_level>
+    <log_alert_level><%= @ossec_log_alert_level %></log_alert_level>
 	<email_alert_level><%= @ossec_email_alert_level %></email_alert_level>
   </alerts>
 


### PR DESCRIPTION
Your module is very useful thanks for that.
We need to modify the parameter log_alert_level, so I made it an argument and set the default value for that to 1, which was the hard coded default before.