### PR TITLE
Increase seq for newline

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class ossec::params {
           }
 
           case $::lsbdistcodename {
-            /(precise|trusty|vivid|wily|xenial)/: {
+            /(bionic|precise|trusty|vivid|wily|xenial)/: {
               $server_service = 'ossec'
               $server_package = 'ossec-hids'
             }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -163,7 +163,7 @@ class ossec::server (
     }
     concat::fragment { 'var_ossec_etc_client.keys_end' :
       target  => $ossec::params::keys_file,
-      order   => 99,
+      order   => 999999,
       content => "\n",
       notify  => Service[$ossec::params::server_service]
     }

--- a/metadata.json
+++ b/metadata.json
@@ -39,6 +39,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "Bionic",
         "Precise",
         "Trusty",
         "Vivid",


### PR DESCRIPTION
When you have more then 99 servers the client keys for
server with agent_id 990 or 999 will come after the newline.
This causes ossec-remoted to exit with an error such as
the following and then ossec-remoted will accept inbound
connections at all.

2018/07/18 08:38:52 ossec-remoted(1401): ERROR: Error reading authentication key: '
'.

I know some organizations will have more then 99999 servers/vms so this improvement
is not perfect but will suffice for majority of companies/organizations I hope.