### PR TITLE
Increase order for concat that adds a newline

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -163,7 +163,7 @@ class ossec::server (
     }
     concat::fragment { 'var_ossec_etc_client.keys_end' :
       target  => $ossec::params::keys_file,
-      order   => 99,
+      order   => 999999,
       content => "\n",
       notify  => Service[$ossec::params::server_service]
     }


### PR DESCRIPTION
When you have more then 99 servers the client keys for
server with agent_id 990 or 999 will come after the newline.
This causes ossec-remoted to exit with an error such as
the following and then ossec-remoted will accept inbound
connections at all.

2018/07/18 08:38:52 ossec-remoted(1401): ERROR: Error reading authentication key: '
'.

I know some organizations will have more then 99999 servers/vms so
this bugfix is not perfect.