### PR TITLE
Add apt_key_options variable for repo class

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -27,6 +27,7 @@ class ossec::repo (
 
   case $::osfamily {
     'Debian' : {
+      notice("The value is: ${apt_key_options}")
       # apt-key added by issue #34
       apt::key { 'puppetlabs':
         id      => '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,6 @@
 # Repo installation
 class ossec::repo (
-  $redhat_manage_epel = true,
+  $redhat_manage_epel   = true,
   $apt_key_options      = undef,
 ) {
   file { '/usr/src/ossec':
@@ -27,7 +27,6 @@ class ossec::repo (
 
   case $::osfamily {
     'Debian' : {
-      notice("The value is: ${apt_key_options}")
       # apt-key added by issue #34
       apt::key { 'puppetlabs':
         id      => '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,7 @@
 # Repo installation
 class ossec::repo (
   $redhat_manage_epel = true,
+  $apt_key_options      = undef,
 ) {
   file { '/usr/src/ossec':
     ensure => directory,
@@ -28,9 +29,10 @@ class ossec::repo (
     'Debian' : {
       # apt-key added by issue #34
       apt::key { 'puppetlabs':
-        id     => '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',
-        source => 'https://ossec.wazuh.com/repos/apt/conf/ossec-key.gpg.key',
-        server => 'pgp.mit.edu'
+        id      => '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',
+        source  => 'https://ossec.wazuh.com/repos/apt/conf/ossec-key.gpg.key',
+        server  => 'pgp.mit.edu',
+        options => $apt_key_options
       }
       case $::lsbdistcodename {
         /(precise|trusty|vivid|wily|xenial|yakketi)/: {


### PR DESCRIPTION
This small fix allow to set a rpoxy for apt-key command. Can be usefull.
Example : 
  apt_key_options => 'http-proxy="http://proxyuser:proxypass@example.org:3128"',

By default variable is undef and has no effect on the module